### PR TITLE
Add pkgdown workflow for GitHub Pages deployment

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,55 @@
+name: pkgdown
+
+on:
+  push:
+    branches: ["main", "master"]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pkgdown
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+      - name: Build site
+        run: pkgdown::build_site(preview = FALSE, new_process = FALSE)
+        shell: Rscript {0}
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,11 +5,13 @@ Authors@R: person("Gaurav Sood", email = "gsood07@gmail.com", role = c("aut", "c
 Author: Gaurav Sood [aut, cre]
 Maintainer: Gaurav Sood <gsood07@gmail.com>
 Description: Provides high-performance join operations for large data frames using
-    Bloom filters to reduce memory usage and improve performance. The package is 
+    Bloom filters to reduce memory usage and improve performance. The package is
     particularly effective when joining a large data frame with a smaller lookup table,
     and when many keys in the larger data frame don't have matches. Features include
     optimized C++ implementation, intelligent join strategy selection, comprehensive
     NA handling, and support for all standard join types.
+URL: https://soodoku.github.io/bloomjoin/, https://github.com/soodoku/bloomjoin
+BugReports: https://github.com/soodoku/bloomjoin/issues
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ BloomJoin provides an alternative join implementation for R that uses an actual 
 devtools::install_github("gojiplus/bloomjoin")
 ```
 
+## Documentation
+
+The full pkgdown site, including function reference, articles, and release notes, is published automatically to GitHub Pages whenever changes are pushed to the main branch. You can browse it at <https://soodoku.github.io/bloomjoin/>. To rebuild the site locally run:
+
+```r
+pkgdown::build_site()
+```
+
 ## Usage
 
 ```r


### PR DESCRIPTION
## Summary
- add a pkgdown GitHub Actions workflow that builds the site and deploys it to GitHub Pages
- document the hosted site location and local build instructions in the README
- add package metadata links for the website and issue tracker

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d0d540d37c832fa3d43d45b043001c