### PR TITLE
Add reproducible usage and benchmarking examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,42 @@ result <- bloom_join(df1, df2,
                     verbose = TRUE)
 ```
 
+### Proof of Correctness
+
+```r
+library(dplyr)
+library(tibble)
+
+set.seed(123)
+left <- tibble(id = sample(1:5000, 4000), value_left = rnorm(4000))
+right <- tibble(id = sample(1:5000, 1500), value_right = rnorm(1500))
+
+bloom <- bloom_join(left, right, by = "id") %>% arrange(id)
+reference <- inner_join(left, right, by = "id") %>% arrange(id)
+
+stopifnot(identical(bloom, reference))
+```
+
+### Benchmarking Time and Memory
+
+```r
+library(bench)
+
+bench::mark(
+  bloom_join = bloom_join(left, right, by = "id"),
+  dplyr_join = inner_join(left, right, by = "id"),
+  iterations = 5,
+  check = FALSE
+)
+```
+
+For a ready-to-run demonstration that generates data, verifies correctness, and
+prints benchmark summaries, execute:
+
+```sh
+Rscript inst/scripts/usage-and-benchmark.R
+```
+
 ## How It Works
 
 BloomJoin uses a Bloom filter pre-processing step to optimize joins:

--- a/inst/scripts/usage-and-benchmark.R
+++ b/inst/scripts/usage-and-benchmark.R
@@ -1,0 +1,89 @@
+#!/usr/bin/env Rscript
+
+# Example usage and benchmarking script for the bloomjoin package.
+#
+# The script demonstrates:
+#   * Building sample data frames with controllable overlap
+#   * Verifying that bloom_join() returns the same rows as dplyr joins
+#   * Benchmarking execution time and memory allocations with bench::mark()
+#
+# Run from the package root with:
+#   Rscript inst/scripts/usage-and-benchmark.R
+
+suppressPackageStartupMessages({
+  library(bloomjoin)
+  library(dplyr)
+  library(tibble)
+  library(bench)
+})
+
+# Generate reproducible test data with a tunable overlap percentage.
+generate_data <- function(n_left, n_right, overlap_pct = 0.1, seed = 42) {
+  set.seed(seed)
+
+  n_overlap <- round(min(n_left, n_right) * overlap_pct)
+  key_pool <- sample(seq_len(n_left + n_right), n_left + n_right - n_overlap)
+
+  left_ids <- key_pool[seq_len(n_left)]
+  right_ids <- c(
+    sample(left_ids, n_overlap),
+    key_pool[(n_left + 1):(n_left + n_right - n_overlap)]
+  )
+
+  left <- tibble(
+    id = left_ids,
+    value_left = rnorm(n_left),
+    group_left = sample(LETTERS[1:4], n_left, replace = TRUE)
+  )
+
+  right <- tibble(
+    id = sample(right_ids),
+    value_right = rnorm(n_right),
+    flag_right = sample(c(TRUE, FALSE), n_right, replace = TRUE)
+  )
+
+  list(left = left, right = right)
+}
+
+# Validate correctness against dplyr joins.
+validate_correctness <- function(data) {
+  bloom <- bloom_join(data$left, data$right, by = "id") %>% arrange(id)
+  reference <- inner_join(data$left, data$right, by = "id") %>% arrange(id)
+
+  if (!identical(bloom, reference)) {
+    stop("bloom_join results diverge from dplyr::inner_join")
+  }
+
+  message("✅ bloom_join matches dplyr::inner_join for the sample data")
+}
+
+# Benchmark time and memory using bench::mark()
+run_benchmark <- function(data, iterations = 5) {
+  bench::mark(
+    bloom_join = bloom_join(data$left, data$right, by = "id"),
+    dplyr_join = inner_join(data$left, data$right, by = "id"),
+    iterations = iterations,
+    check = FALSE
+  )
+}
+
+main <- function() {
+  message("=== bloomjoin usage and benchmark demo ===")
+  sample_data <- generate_data(75000, 2500, overlap_pct = 0.05)
+
+  message("\nValidating correctness...")
+  validate_correctness(sample_data)
+
+  message("\nBenchmarking (time & memory)...")
+  bench_results <- run_benchmark(sample_data, iterations = 5)
+  print(bench_results[, c("expression", "median", "itr/sec", "mem_alloc", "gc")])
+
+  ratio <- bench_results$median[bench_results$expression == "dplyr_join"] /
+    bench_results$median[bench_results$expression == "bloom_join"]
+  message(sprintf("\nRelative speed-up (dplyr / bloom): %.2fx", ratio))
+}
+
+if (sys.nframe() == 0) {
+  main()
+}
+

--- a/vignettes/benchmarking-bloomjoin.Rmd
+++ b/vignettes/benchmarking-bloomjoin.Rmd
@@ -28,6 +28,25 @@ library(dplyr)
 library(tibble)
 library(ggplot2)
 library(microbenchmark)
+library(bench)
+```
+
+## Correctness Validation
+
+Before diving into performance, let's ensure that `bloom_join()` produces the
+same results as the equivalent `dplyr` verbs.
+
+```{r correctness-check}
+test_data <- generate_test_data(1000, 800, 0.15)
+
+bloom_result <- bloom_join(test_data$left, test_data$right, by = "id")
+baseline_result <- inner_join(test_data$left, test_data$right, by = "id")
+
+# Sort columns and rows to make comparison deterministic
+arranged_bloom <- arrange(bloom_result, id)
+arranged_baseline <- arrange(baseline_result, id)
+
+stopifnot(identical(arranged_bloom, arranged_baseline))
 ```
 
 ## Performance Testing Framework
@@ -223,43 +242,31 @@ cat("so performance is similar to standard joins.\n")
 
 ## Memory Usage Analysis
 
-Let's examine memory efficiency:
+Let's examine memory efficiency using the `bench` package, which records peak
+memory allocations alongside execution time:
 
 ```{r memory-analysis}
 cat("=== MEMORY USAGE ANALYSIS ===\n")
 
-# Function to measure memory usage
-measure_memory_usage <- function(n_left, n_right, overlap_pct) {
+memory_benchmark <- function(n_left, n_right, overlap_pct, iterations = 5) {
   test_data <- generate_test_data(n_left, n_right, overlap_pct)
-  
-  # Measure bloom_join memory
-  gc()
-  mem_before <- sum(gc()[,2])
-  bloom_result <- bloom_join(test_data$left, test_data$right, by = "id")
-  mem_after <- sum(gc()[,2])
-  bloom_memory <- mem_after - mem_before
-  
-  # Measure dplyr join memory  
-  gc()
-  mem_before <- sum(gc()[,2])
-  dplyr_result <- inner_join(test_data$left, test_data$right, by = "id")
-  mem_after <- sum(gc()[,2])
-  dplyr_memory <- mem_after - mem_before
-  
-  list(
-    bloom_memory = bloom_memory,
-    dplyr_memory = dplyr_memory,
-    memory_ratio = dplyr_memory / bloom_memory
+
+  bench::mark(
+    bloom_join = bloom_join(test_data$left, test_data$right, by = "id"),
+    dplyr_join = inner_join(test_data$left, test_data$right, by = "id"),
+    iterations = iterations,
+    check = FALSE
   )
 }
 
-# Test memory usage
-memory_test <- measure_memory_usage(25000, 2500, 0.08)
+memory_test <- memory_benchmark(25000, 2500, 0.08, iterations = 5)
 
-cat("Memory usage comparison:\n")
-cat("Bloom join memory delta:", round(memory_test$bloom_memory, 2), "MB\n")
-cat("Dplyr join memory delta:", round(memory_test$dplyr_memory, 2), "MB\n")
-cat("Memory efficiency ratio:", round(memory_test$memory_ratio, 2), "x\n")
+print(memory_test[, c("expression", "median", "mem_alloc", "gc")])
+
+ratio <- memory_test$mem_alloc[memory_test$expression == "dplyr_join"] /
+  memory_test$mem_alloc[memory_test$expression == "bloom_join"]
+
+cat("\nMemory efficiency ratio (dplyr / bloom):", round(ratio, 2), "x\n")
 ```
 
 ## Performance Recommendations


### PR DESCRIPTION
## Summary
- add a correctness validation step and bench-backed memory analysis to the benchmarking vignette
- expand the README with explicit correctness and benchmarking snippets plus instructions for running them
- provide an executable script under inst/scripts that generates data, validates results, and prints time/memory benchmarks

## Testing
- Rscript inst/scripts/usage-and-benchmark.R *(fails: command not found because R is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d895e090832fb93077eb2a206ebb