### PR TITLE
Fix Rcpp wrapper parameter name

### DIFF
--- a/src/hash_keys.cpp
+++ b/src/hash_keys.cpp
@@ -147,7 +147,8 @@ static inline uint64_t hash_elem(SEXP col, R_xlen_t i, bool normalize_strings) {
 // [[Rcpp::export]]
 IntegerVector hash_keys32_cols(List cols,
                                bool normalize_strings = true,
-                               bool /*na_sentinel*/ = true) {
+                               bool na_sentinel = true) {
+  (void)na_sentinel;  // retained for signature compatibility
   if (cols.size() == 0) {
     stop("`cols` must contain at least one column.");
   }


### PR DESCRIPTION
## Summary
- replace the commented placeholder parameter name in `hash_keys32_cols()` with a real identifier
- explicitly ignore the unused `na_sentinel` argument to keep the signature stable without confusing Rcpp attribute generation

## Testing
- not run (Rscript is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0df20551c832fa7d045a5d865a615