### PR TITLE
Fix benchmarking vignette chunk termination

### DIFF
--- a/vignettes/benchmarking-bloomjoin.Rmd
+++ b/vignettes/benchmarking-bloomjoin.Rmd
@@ -96,7 +96,7 @@ stopifnot(identical(arranged_bloom, arranged_baseline))
 stopifnot(
   isTRUE(all.equal(arranged_bloom, arranged_baseline, check.attributes = FALSE))
 )
-
+```
 
 ## Performance Testing Framework
 


### PR DESCRIPTION
## Summary
- close the correctness validation chunk in the benchmarking vignette so knitting completes successfully

## Testing
- not run (Rscript binary not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0e3ce6a8c832fa2b2a0871672f064