### PR TITLE
Clear bloom metadata before vignette comparison

### DIFF
--- a/vignettes/benchmarking-bloomjoin.Rmd
+++ b/vignettes/benchmarking-bloomjoin.Rmd
@@ -91,6 +91,7 @@ arranged_baseline <- arrange(baseline_result, id)
 # Drop the bloomjoin-specific metadata/class so we compare the raw data only
 arranged_bloom <- as.data.frame(arranged_bloom)
 arranged_baseline <- as.data.frame(arranged_baseline)
+attr(arranged_bloom, "bloom_metadata") <- NULL
 
 stopifnot(identical(arranged_bloom, arranged_baseline))
 stopifnot(


### PR DESCRIPTION
## Summary
- clear the bloom_metadata attribute from the bloom_join result in the benchmarking vignette before comparing it to the baseline join output

## Testing
- Rscript -e "devtools::test(filter = 'bloom_join', stop_on_failure = TRUE)" *(fails: Rscript not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e4d4b87c832f8795626bb94b6965