### PR TITLE
Handle bloom prefilter overrides consistently

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(bloom_join)
 export(bloom_params)
 export(hash_keys32)
+S3method(all.equal,bloomjoin)
 S3method(print,bloom_params)
 importFrom(Rcpp,evalCpp)
 importFrom(Rcpp,sourceCpp)


### PR DESCRIPTION
## Summary
- ensure bloom prefilter overrides are recorded even when the plan falls back to a standard join
- use the original full-join reason text so metadata from overridden and default plans match
- add an `all.equal.bloomjoin()` S3 method so bloomjoin objects compare equality based on join results, not diagnostic metadata

## Testing
- `R -q -e "devtools::test()"` *(fails: R is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e7dd1e04832f9be48dc49de0dad3