### PR TITLE
Register waldo proxy to ignore bloom metadata in comparisons

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Suggests:
     knitr (>= 1.11),
     microbenchmark,
     bench,
-    ggplot2
+    ggplot2,
+    waldo
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,15 @@
+.onLoad <- function(libname, pkgname) {
+  if (requireNamespace("waldo", quietly = TRUE)) {
+    registerS3method(
+      "compare_proxy",
+      "bloomjoin",
+      compare_proxy.bloomjoin,
+      envir = asNamespace("waldo")
+    )
+  }
+}
+
+compare_proxy.bloomjoin <- function(x, path, ...) {
+  x <- strip_bloomjoin_attributes(x)
+  NextMethod()
+}


### PR DESCRIPTION
## Summary
- register a waldo `compare_proxy()` method for the `bloomjoin` class so equality checks ignore bloom metadata
- add waldo to the Suggests field because the proxy registration is optional

## Testing
- not run (R is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d0e9965f5c832faa1e34098d776d18